### PR TITLE
smtpd.php: fixing GM_ALLOWED_HOSTS's first domain not allowed

### DIFF
--- a/smtpd.php
+++ b/smtpd.php
@@ -166,7 +166,7 @@ if (!function_exists('is_host_allowed')) {
             }
         }
         if (isset($hosts[$host])) {
-            return $hosts[$host];
+            return is_numeric($hosts[$host]);
         }
         return false;
     }


### PR DESCRIPTION
current proposed is_host_allowed() implementation returns 0 when the current sender's email address domain is first in GM_ALLOWED_HOSTS's comma separated values. This makes if(is_host_allowed()) tests in other places in this file to fail because 0 is interpreted as false. Adding is_numeric() before return in is_host_allowed() to force sending either true or false, but never 0 (or another integer).
