### PR TITLE
Does not check MySQL settings if MySQL is not used

### DIFF
--- a/smtpd.php
+++ b/smtpd.php
@@ -250,7 +250,7 @@ function get_db_link($reconnect = false)
 $GM_ERROR = false;
 // Check MySQL connection
 
-if (get_db_link() === false) {
+if (defined('MYSQL_HOST') && get_db_link() === false) {
     die('Please check your MySQL settings');
 }
 


### PR DESCRIPTION
We don't use MySQL thanks to a custom save_email_function, so the check for MySQL is useless in our case. This pull-request works in a way that if MYSQL_HOST is not defined, the MySQL settings are not checked.
